### PR TITLE
Add support for snort/suricata output

### DIFF
--- a/certau/transform/__init__.py
+++ b/certau/transform/__init__.py
@@ -13,16 +13,20 @@ There are two broad types of transform currently supported:
      * :py:class:`StixCsvTransform` - display indicators in CSV format
      * :py:class:`StixBroIntelTransform` - display indicators in the Bro
        Intel format
+     * :py:class:`StixSnortTransform` - display indicators in the Snort
+       rule format
 
 #. Transforms that interact with a service:
      * :py:class:`StixMispTransform` - publish indicators to a MISP instance
 """
 
-__all__ = ['base', 'text', 'stats', 'csv', 'brointel', 'misp']
+__all__ = ['base', 'text', 'stats', 'csv', 'brointel', 'misp', 'snort']
+
 
 from .base import StixTransform
 from .text import StixTextTransform
 from .stats import StixStatsTransform
 from .csv import StixCsvTransform
 from .brointel import StixBroIntelTransform
+from .snort import StixSnortTransform
 from .misp import StixMispTransform

--- a/certau/transform/snort.py
+++ b/certau/transform/snort.py
@@ -1,0 +1,113 @@
+import re
+
+from cybox.objects.address_object import Address
+from cybox.objects.uri_object import URI
+import pprint
+
+from .text import StixTextTransform
+
+
+class StixSnortTransform(StixTextTransform):
+    """Generate observable details for Snort.
+
+    This class can be used to generate a list of indicators (observables)
+    from a STIX package in a format suitable for importing into the Snort
+    network-based intrusion detection system as Snort rules.
+
+    Args:
+        package: the STIX package to process
+        separator: a string separator used in the text output
+        include_header: a boolean value that indicates whether or not header
+            information should be included in the text output
+        header_prefix: a string prepended to header lines in the output
+        source: a value to include in the output metadata field 'meta.source'
+        url: a value to include in the output field metadata 'meta.url'
+        do_notice: a value to include in the output metadata field
+            'meta.do_notice', if set to 'T' a Bro notice will be raised by Bro
+            on a match of this indicator
+    """
+
+    RULE_CONTENT = 'alert ip any any -> <BADIP> any (flow:established,to_server; msg:"CTI-TOOLKIT Connection to potentially malicious server <BADIP>", sid:<SNORTID>; rev:1; classtype:bad-unknown;)'
+
+    OBJECT_FIELDS = {
+        'Address': ['address_value'],
+        'DomainName': ['value'],
+        'EmailMessage': [
+            'header.from_.address_value',
+            'header.to.address_value',
+        ],
+        'File': ['hashes.simple_hash_value'],
+        'HTTPSession': ['http_request_response.http_client_request.' +
+                        'http_request_header.parsed_header.user_agent'],
+        'SocketAddress': ['ip_address.address_value'],
+        'URI': ['value'],
+    }
+
+    OBJECT_CONSTRAINTS = {
+        'Address': {
+            'category': [Address.CAT_IPV4, Address.CAT_IPV6],
+        },
+        'URI': {
+            'type_': [URI.TYPE_URL],
+        },
+    }
+
+    STRING_CONDITION_CONSTRAINT = ['None', 'Equals']
+
+    HEADER_LABELS = [
+        'indicator', 'indicator_type', 'meta.source', 'meta.url',
+        'meta.do_notice', 'meta.if_in', 'meta.whitelist',
+    ]
+
+    # Map Cybox object type to Bro Intel types.
+    BIF_TYPE_MAPPING = {
+        'Address': 'Intel::ADDR',
+        'DomainName': 'Intel::DOMAIN',
+        'EmailMessage': 'Intel::EMAIL',
+        'File': 'Intel::FILE_HASH',
+        'HTTPSession': 'Intel::SOFTWARE',
+        'SocketAddress': 'Intel::ADDR',
+        'URI': 'Intel::URL',
+    }
+
+    # Map observable id prefix to source and url.
+    BIF_SOURCE_MAPPING = {
+        'cert_au': {
+            'source': 'CERT-AU',
+            'url': 'https://www.cert.gov.au/',
+        },
+        'CCIRC-CCRIC': {
+            'source': 'CCIRC',
+            'url': ('https://www.publicsafety.gc.ca/' +
+                    'cnt/ntnl-scrt/cbr-scrt/ccirc-ccric-eng.aspx'),
+        },
+        'NCCIC': {
+            'source': 'NCCIC',
+            'url': 'https://www.us-cert.gov/',
+        },
+    }
+
+    def __init__(self, package, separator='\t', include_header=False,
+                 include_observable_id=True,
+                 snort_initial_sid=5500000, snort_rule_revision=1, snort_rule_action="alert"):
+        super(StixSnortTransform, self).__init__(
+            package, separator, include_header, include_observable_id,
+        )
+        self._sid = int(snort_initial_sid)
+        self._snort_rule_revision = int(snort_rule_revision)
+        self._snort_rule_action = snort_rule_action
+
+    def text_for_object_type(self, object_type):
+        text = ''
+        if object_type in self._observables:
+            for observable in self._observables[object_type]:
+                id_ = observable['id']
+                for field in observable['fields']:
+                    try:
+                        ip = field["address_value"]
+                        text += '{} ip any any -> {} any (flow:established,to_server; msg:"CTI-TOOLKIT Connection to potentially malicious server {} (ID {})", sid:{}; rev:{}; classtype:bad-unknown;)\n'.format(self._snort_rule_action, ip, ip, id_, self._sid, self._snort_rule_revision)
+                    except KeyError:
+                        pass
+                    else:
+                        self._sid += 1
+        return text

--- a/certau/transform/snort.py
+++ b/certau/transform/snort.py
@@ -2,7 +2,6 @@ import re
 
 from cybox.objects.address_object import Address
 from cybox.objects.uri_object import URI
-import pprint
 
 from .text import StixTextTransform
 

--- a/certau/transform/snort.py
+++ b/certau/transform/snort.py
@@ -14,10 +14,11 @@ class StixSnortTransform(StixTextTransform):
     network-based intrusion detection system as Snort rules.
 
     Args:
-        package: the STIX package to process
-        separator: a string separator used in the text output
-        include_observable_id: a boolean value that indicates whether or not
-            the observable id should be included in the text output
+        package: the STIX package to transform
+        separator: the delimiter used in text output
+        include_header: a boolean value indicating whether
+            or not headers should be included in the output
+        header_prefix: a string prepended to each header row
         snort_initial_sid: the initial snort rule number the script should start
             counting from.
         snort_rule_revision: a number indicating which revision of the snort rule
@@ -42,10 +43,9 @@ class StixSnortTransform(StixTextTransform):
     }
 
     def __init__(self, package, separator='\t', include_header=False,
-                 header_prefix='#', include_observable_id=True,
-                 snort_initial_sid=5500000, snort_rule_revision=1, snort_rule_action="alert"):
+                 header_prefix='#', snort_initial_sid=5500000, snort_rule_revision=1, snort_rule_action="alert"):
         super(StixSnortTransform, self).__init__(
-            package, separator, include_header, header_prefix,
+            package, separator, include_header, header_prefix
         )
         self._sid = int(snort_initial_sid)
         self._snort_rule_revision = int(snort_rule_revision)

--- a/certau/transform/snort.py
+++ b/certau/transform/snort.py
@@ -17,75 +17,16 @@ class StixSnortTransform(StixTextTransform):
     Args:
         package: the STIX package to process
         separator: a string separator used in the text output
-        include_header: a boolean value that indicates whether or not header
-            information should be included in the text output
-        header_prefix: a string prepended to header lines in the output
-        source: a value to include in the output metadata field 'meta.source'
-        url: a value to include in the output field metadata 'meta.url'
-        do_notice: a value to include in the output metadata field
-            'meta.do_notice', if set to 'T' a Bro notice will be raised by Bro
-            on a match of this indicator
+        include_observable_id: a boolean value that indicates whether or not
+            the observable id should be included in the text output
+        snort_initial_sid: the initial snort rule number the script should start
+            counting from.
+        snort_rule_revision: a number indicating which revision of the snort rule
+            should be generated. The default is 1 (first version of the rule).
+        snort_rule_action: a value from the following list that indicates the rule
+            action that all generated snort rules will have:
+            [alert|log|pass|activate|dynamic|drop|reject|sdrop]
     """
-
-    RULE_CONTENT = 'alert ip any any -> <BADIP> any (flow:established,to_server; msg:"CTI-TOOLKIT Connection to potentially malicious server <BADIP>", sid:<SNORTID>; rev:1; classtype:bad-unknown;)'
-
-    OBJECT_FIELDS = {
-        'Address': ['address_value'],
-        'DomainName': ['value'],
-        'EmailMessage': [
-            'header.from_.address_value',
-            'header.to.address_value',
-        ],
-        'File': ['hashes.simple_hash_value'],
-        'HTTPSession': ['http_request_response.http_client_request.' +
-                        'http_request_header.parsed_header.user_agent'],
-        'SocketAddress': ['ip_address.address_value'],
-        'URI': ['value'],
-    }
-
-    OBJECT_CONSTRAINTS = {
-        'Address': {
-            'category': [Address.CAT_IPV4, Address.CAT_IPV6],
-        },
-        'URI': {
-            'type_': [URI.TYPE_URL],
-        },
-    }
-
-    STRING_CONDITION_CONSTRAINT = ['None', 'Equals']
-
-    HEADER_LABELS = [
-        'indicator', 'indicator_type', 'meta.source', 'meta.url',
-        'meta.do_notice', 'meta.if_in', 'meta.whitelist',
-    ]
-
-    # Map Cybox object type to Bro Intel types.
-    BIF_TYPE_MAPPING = {
-        'Address': 'Intel::ADDR',
-        'DomainName': 'Intel::DOMAIN',
-        'EmailMessage': 'Intel::EMAIL',
-        'File': 'Intel::FILE_HASH',
-        'HTTPSession': 'Intel::SOFTWARE',
-        'SocketAddress': 'Intel::ADDR',
-        'URI': 'Intel::URL',
-    }
-
-    # Map observable id prefix to source and url.
-    BIF_SOURCE_MAPPING = {
-        'cert_au': {
-            'source': 'CERT-AU',
-            'url': 'https://www.cert.gov.au/',
-        },
-        'CCIRC-CCRIC': {
-            'source': 'CCIRC',
-            'url': ('https://www.publicsafety.gc.ca/' +
-                    'cnt/ntnl-scrt/cbr-scrt/ccirc-ccric-eng.aspx'),
-        },
-        'NCCIC': {
-            'source': 'NCCIC',
-            'url': 'https://www.us-cert.gov/',
-        },
-    }
 
     def __init__(self, package, separator='\t', include_header=False,
                  include_observable_id=True,

--- a/config/ctitoolkit.conf.sample
+++ b/config/ctitoolkit.conf.sample
@@ -25,8 +25,16 @@ ssl: true
 # Flag to indicate that taxii to be used (as opposed to reading a file)
 taxii: true
 
-# This setting specifies the snort rule ID that the ctitoolkit will use.
+# This setting specifies the initial snort rule ID that the ctitoolkit will use to start from.
 # To include your own rules, assign a sid between 5000000-5999999
 # and add it to local.rules and run: perl /usr/share/ossim/scripts/create_sidmap.pl /etc/snort/rules/
 # and restart snort: /etc/init.d/snort restart
-snort-sid-range: 5000000-5999999
+#snort-initial-sid: 5500000
+
+# This setting specifies the revision number of the generated rules. It defaults to the
+# first revision (the first version of the rule).
+#snort-rule-revision: 1
+
+# This setting specifies the rule action that all generated rules will have.
+# The options are: [alert|log|pass|activate|dynamic|drop|reject|sdrop]
+#snort-rule-action: alert

--- a/config/ctitoolkit.conf.sample
+++ b/config/ctitoolkit.conf.sample
@@ -24,3 +24,9 @@ ssl: true
 
 # Flag to indicate that taxii to be used (as opposed to reading a file)
 taxii: true
+
+# This setting specifies the snort rule ID that the ctitoolkit will use.
+# To include your own rules, assign a sid between 5000000-5999999
+# and add it to local.rules and run: perl /usr/share/ossim/scripts/create_sidmap.pl /etc/snort/rules/
+# and restart snort: /etc/init.d/snort restart
+snort-sid-range: 5000000-5999999

--- a/docs/certau/transform.rst
+++ b/docs/certau/transform.rst
@@ -17,5 +17,7 @@
 
 .. autoclass:: certau.transform.StixBroIntelTransform
 
+.. autoclass:: certau.transform.StixSnortTransform
+
 .. autoclass:: certau.transform.StixMispTransform
     :members: get_misp_object

--- a/docs/scripts/stixtransclient.rst
+++ b/docs/scripts/stixtransclient.rst
@@ -4,8 +4,11 @@
 Few systems can utilise indicators and observables when stored in STIX packages.
 CERT Australia has developed a utility (``stixtransclient.py``) that allows the
 atomic observables contained within a STIX package to be extracted and presented
-in either a text delimited format, or in the `Bro Intel Framework
-<http://blog.bro.org/2014/01/intelligence-data-and-bro_4980.html>`_ format.
+in either a text delimited format, in the `Bro Intel Framework
+<http://blog.bro.org/2014/01/intelligence-data-and-bro_4980.html>`_ format, or in
+a `Snort
+<https://snort.org/>`_ or `Suricata
+<https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Suricata>`_ rule format .
 The utility can also communicate with a `MISP
 <http://www.misp-project.org/>`_ server and insert observables from a STIX
 package into a new MISP event.
@@ -109,6 +112,22 @@ Display observables in the format used by the Bro Intelligence Framework
     183.82.180.95	Intel::ADDR	CCIRC	https://www.publicsafety.gc.ca/cnt/ntnl-scrt/cbr-scrt/ccirc-ccric-eng.aspx	T	-	-
     host.domain.tld/path/file	Intel::URL	CERT-AU	https://www.cert.gov.au/	T	-	-
 
+Display IP observables in the format used by Snort IDS starting with a snort rule id of 5590000
+(Note - Each run of stixtransclient.py will need a different sids::
+
+    $ stixtransclient.py --file CA-TEST-STIX.xml --snort --snort-initial-sid 5590000
+
+    alert ip any any -> 188.115.196.39 any (flow:established,to_server; msg:"CTI-TOOLKIT Connection to potentially malicious server 188.115.196.39 (ID cert_au:Observable-6a47b9da-ee08-413e-81ca-a3bb2ad46db4)", sid:5590000; rev:1; classtype:bad-unknown;)
+    alert ip any any -> 59.210.83.95 any (flow:established,to_server; msg:"CTI-TOOLKIT Connection to potentially malicious server 59.210.83.95 (ID cert_au:Observable-0e1f6465-e9c2-4409-9e2b-29189bbd6ca0)", sid:5590001; rev:1; classtype:bad-unknown;)
+    alert ip any any -> 217.105.97.215 any (flow:established,to_server; msg:"CTI-TOOLKIT Connection to potentially malicious server 217.105.97.215 (ID cert_au:Observable-f19853c3-4ce9-465f-9d5a-b194f85016ee)", sid:5590002; rev:1; classtype:bad-unknown;)
+    alert ip any any -> 147.93.7.4 any (flow:established,to_server; msg:"CTI-TOOLKIT Connection to potentially malicious server 147.93.7.4 (ID cert_au:Observable-15404e6d-6c09-4c5c-8024-14b55d8dee66)", sid:5590003; rev:1; classtype:bad-unknown;)
+    alert ip any any -> 203.95.198.169 any (flow:established,to_server; msg:"CTI-TOOLKIT Connection to potentially malicious server 203.95.198.169 (ID cert_au:Observable-f5832d9a-894c-4667-a1c7-2b37f5048740)", sid:5590004; rev:1; classtype:bad-unknown;)
+    alert ip any any -> 110.244.163.122 any (flow:established,to_server; msg:"CTI-TOOLKIT Connection to potentially malicious server 110.244.163.122 (ID cert_au:Observable-f7b8c56b-1a69-4d02-99ee-30e9bdd59452)", sid:5590005; rev:1; classtype:bad-unknown;)
+    alert ip any any -> 248.206.70.230 any (flow:established,to_server; msg:"CTI-TOOLKIT Connection to potentially malicious server 248.206.70.230 (ID cert_au:Observable-5ad9e361-f32f-4174-b854-27bb73d77645)", sid:5590006; rev:1; classtype:bad-unknown;)
+    alert ip any any -> 99.253.98.57 any (flow:established,to_server; msg:"CTI-TOOLKIT Connection to potentially malicious server 99.253.98.57 (ID cert_au:Observable-1526c98f-950e-46da-931a-3749524c519f)", sid:5590007; rev:1; classtype:bad-unknown;)
+    alert ip any any -> 3.46.87.116 any (flow:established,to_server; msg:"CTI-TOOLKIT Connection to potentially malicious server 3.46.87.116 (ID cert_au:Observable-62fb38b3-fc53-48cb-ad7d-6a9762ee87c4)", sid:5590008; rev:1; classtype:bad-unknown;)
+    alert ip any any -> 28.13.163.200 any (flow:established,to_server; msg:"CTI-TOOLKIT Connection to potentially malicious server 28.13.163.200 (ID cert_au:Observable-091354ba-6db5-42a6-8db0-1041b148ba28)", sid:5590009; rev:1; classtype:bad-unknown;)
+
 
 Command line options (help)
 ---------------------------
@@ -120,8 +139,9 @@ displayed below::
     
     usage: stixtransclient.py [-h] [-c CONFIG] [-v] [-d]
                               (--file FILE [FILE ...] | --taxii)
-                              (-s | -t | -b | -m | -x XML_OUTPUT) [-r]
-                              [--hostname HOSTNAME] [--username USERNAME]
+                              (-s | -t | -b | -m | -sn | -x XML_OUTPUT) [-r]
+                              [--hostname HOSTNAME] [--port PORT]
+                              [--ca_file CA_FILE] [--username USERNAME]
                               [--password PASSWORD] [--ssl] [--key KEY]
                               [--cert CERT] [--path PATH]
                               [--collection COLLECTION]
@@ -130,8 +150,11 @@ displayed below::
                               [--subscription-id SUBSCRIPTION_ID]
                               [-f FIELD_SEPARATOR] [--header] [--title TITLE]
                               [--source SOURCE] [--bro-no-notice]
-                              [--base-url BASE_URL] [--misp-url MISP_URL]
-                              [--misp-key MISP_KEY]
+                              [--base-url BASE_URL]
+                              [--snort-initial-sid SNORT_INITIAL_SID]
+                              [--snort-rule-revision SNORT_RULE_REVISION]
+                              [--snort-rule-action SNORT_RULE_ACTION]
+                              [--misp-url MISP_URL] [--misp-key MISP_KEY]
                               [--misp-distribution MISP_DISTRIBUTION]
                               [--misp-threat MISP_THREAT]
                               [--misp-analysis MISP_ANALYSIS]
@@ -166,6 +189,7 @@ displayed below::
       -t, --text            output observables in delimited text
       -b, --bro             output observables in Bro intel framework format
       -m, --misp            feed output to a MISP server
+      -sn, --snort          output observables in Snort rule format
       -x XML_OUTPUT, --xml_output XML_OUTPUT
                             output XML STIX packages to the given directory (use
                             with --taxii)
@@ -175,6 +199,8 @@ displayed below::
 
     taxii input arguments (use with --taxii):
       --hostname HOSTNAME   hostname of TAXII server
+      --port PORT           port of TAXII server
+      --ca_file CA_FILE     File containing CA certs of TAXII server
       --username USERNAME   username for TAXII authentication
       --password PASSWORD   password for TAXII authentication
       --ssl                 use SSL to connect to TAXII server
@@ -204,6 +230,15 @@ displayed below::
       --base-url BASE_URL   base URL for indicator source - use with --bro or
                             --misp
 
+    snort output arguments (use with --snort):
+      --snort-initial-sid SNORT_INITIAL_SID
+                            The initial Snort IDs to begin from (default: 5500000)
+      --snort-rule-revision SNORT_RULE_REVISION
+                            The revision of the Snort rule (default: 1)
+      --snort-rule-action SNORT_RULE_ACTION
+                            Change all Snort rules generated to
+                            [alert|log|pass|activate|dynamic|drop|reject|sdrop]
+
     misp output arguments (use with --misp):
       --misp-url MISP_URL   URL of MISP server
       --misp-key MISP_KEY   token for accessing MISP instance
@@ -215,6 +250,5 @@ displayed below::
       --misp-analysis MISP_ANALYSIS
                             MISP analysis phase - default: 0 (initial)
       --misp-info MISP_INFO
-                            MISP event description - default: 'Automated STIX
-                            ingest'
+                            MISP event description
       --misp-published      set MISP published state to True

--- a/scripts/stixtransclient.py
+++ b/scripts/stixtransclient.py
@@ -14,7 +14,7 @@ from stix.core import STIXPackage
 from certau.source import StixFileSource, SimpleTaxiiClient
 from certau.transform import StixTextTransform, StixStatsTransform
 from certau.transform import StixCsvTransform, StixBroIntelTransform
-from certau.transform import StixMispTransform
+from certau.transform import StixMispTransform, StixSnortTransform
 
 
 def get_arg_parser():
@@ -81,6 +81,11 @@ def get_arg_parser():
         "-m", "--misp",
         action="store_true",
         help="feed output to a MISP server",
+    )
+    output_ex_group.add_argument(
+        "-sn", "--snort",
+        action="store_true",
+        help="output observables in Snort rule format",
     )
     output_ex_group.add_argument(
         "-x", "--xml_output",
@@ -184,6 +189,21 @@ def get_arg_parser():
         "--base-url",
         help="base URL for indicator source - use with --bro or --misp",
     )
+    snort_group = parser.add_argument_group(
+        title='snort output arguments (use with --snort)',
+    )
+    snort_group.add_argument(
+        "--snort-initial-sid",
+        help="The initial Snort IDs to begin from (default: 5500000)",
+    )
+    snort_group.add_argument(
+        "--snort-rule-revision",
+        help="The revision of the Snort rule (default: 1)",
+    )
+    snort_group.add_argument(
+        "--snort-rule-action",
+        help="Change all Snort rules generated to [alert|log|pass|activate|dynamic|drop|reject|sdrop]",
+    )
     misp_group = parser.add_argument_group(
         title='misp output arguments (use with --misp)',
     )
@@ -268,6 +288,15 @@ def main():
         transform_kwargs['analysis'] = options.misp_analysis
         transform_kwargs['information'] = options.misp_info
         transform_kwargs['published'] = options.misp_published
+    elif options.snort:
+        transform_class = StixSnortTransform
+        if options.snort_initial_sid:
+            transform_kwargs['snort_initial_sid'] = options.snort_initial_sid
+        if options.snort_rule_revision:
+            transform_kwargs['snort_rule_revision'] = options.snort_rule_revision
+        if options.snort_rule_action:
+            allowed_actions = ["alert","log","pass","activate","dynamic","drop","reject","sdrop"]
+            transform_kwargs['snort_rule_action'] = options.snort_rule_action if options.snort_rule_action in allowed_actions else "alert"
     elif options.xml_output:
         pass
     else:

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -173,7 +173,7 @@ def test_transform_to_snort(package):
     )
 
     assert transformer.text().strip().expandtabs() == textwrap.dedent("""
-        alert ip any any -> 158.164.39.51 any (flow:established,to_server; msg:"CTI-TOOLKIT Connection to potentially malicious server 158.164.39.51 (ID cert_au:Observable-fe5ddeac-f9b0-4488-9f89-bfbd9351efd4)"; sid:5500000; rev:1; classtype:bad-unknown;)\n
-        alert ip any any -> 111.222.33.44 any (flow:established,to_server; msg:"CTI-TOOLKIT Connection to potentially malicious server 111.222.33.44 (ID cert_au:Observable-ccccceac-f9b0-4488-9f89-bfbd9351efd4)"; sid:5500001; rev:1; classtype:bad-unknown;)\n
+        alert ip any any -> 158.164.39.51 any (flow:established,to_server; msg:"CTI-TOOLKIT Connection to potentially malicious server 158.164.39.51 (ID cert_au:Observable-fe5ddeac-f9b0-4488-9f89-bfbd9351efd4)"; sid:5500000; rev:1; classtype:bad-unknown;)
+        alert ip any any -> 111.222.33.44 any (flow:established,to_server; msg:"CTI-TOOLKIT Connection to potentially malicious server 111.222.33.44 (ID cert_au:Observable-ccccceac-f9b0-4488-9f89-bfbd9351efd4)"; sid:5500001; rev:1; classtype:bad-unknown;)
     """).strip().expandtabs()
 

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -162,3 +162,18 @@ def test_transform_to_bro(package):
         183.82.180.95\tIntel::ADDR\tCCIRC\thttps://www.publicsafety.gc.ca/cnt/ntnl-scrt/cbr-scrt/ccirc-ccric-eng.aspx\tF\t-\t-
         host.domain.tld/path/file\tIntel::URL\tCERT-AU\thttps://www.cert.gov.au/\tF\t-\t-
     """).strip().expandtabs()
+
+def test_transform_to_snort(package):
+    """Test of transform between a sample STIX file and the 'snort' output
+    format.
+    """
+    # Select 'stats' output format.
+    transformer = certau.transform.StixSnortTransform(
+            package, include_header=False
+    )
+
+    assert transformer.text().strip().expandtabs() == textwrap.dedent("""
+        alert ip any any -> 158.164.39.51 any (flow:established,to_server; msg:"CTI-TOOLKIT Connection to potentially malicious server 158.164.39.51 (ID cert_au:Observable-fe5ddeac-f9b0-4488-9f89-bfbd9351efd4)"; sid:5500000; rev:1; classtype:bad-unknown;)\n
+        alert ip any any -> 111.222.33.44 any (flow:established,to_server; msg:"CTI-TOOLKIT Connection to potentially malicious server 111.222.33.44 (ID cert_au:Observable-ccccceac-f9b0-4488-9f89-bfbd9351efd4)"; sid:5500001; rev:1; classtype:bad-unknown;)\n
+    """).strip().expandtabs()
+


### PR DESCRIPTION
I've added snort/suricata support into the ctitoolkit. There are a few options you can select to modify the behaviour of the Snort Transform:

snort output arguments (use with --snort):
  --snort-initial-sid SNORT_INITIAL_SID
                        The initial Snort IDs to begin from (default: 5500000)
  --snort-rule-revision SNORT_RULE_REVISION
                        The revision of the Snort rule (default: 1)
  --snort-rule-action SNORT_RULE_ACTION
                        Change all Snort rules generated to
                        [alert|log|pass|activate|dynamic|drop|reject|sdrop]

The idea is that the --snort item alone will generate snort rules in the snort ID range that is assigned for local use...5000000-5999999. By default I've set it to be halfway through that range, so that no other local rules will be overwritten. Please note that the snort rules will always generate snort id's starting with 5500000 and upwards each time its run, meaning that rule id collisions **will happen** unless the organisation wishes to wrap this script in a script that will maintain state and supply an unused sid range to the --snort-initial-sid command-line parameter. If this isn't done, then the tool will create an output that will cause cause Snort to error when it starts.