### PR TITLE
Added new output transform StixTestTransform …

### DIFF
--- a/certau/transform/__init__.py
+++ b/certau/transform/__init__.py
@@ -15,12 +15,15 @@ There are two broad types of transform currently supported:
        Intel format
      * :py:class:`StixSnortTransform` - display indicators in the Snort
        rule format
+     * :py:class:`StixTestTransform` - output indicator test mechanims included
+       in the STIX package
 
 #. Transforms that interact with a service:
      * :py:class:`StixMispTransform` - publish indicators to a MISP instance
 """
 
-import sys
+__all__ = ['base', 'text', 'stats', 'csv', 'brointel', 'misp', 'snort', 'test']
+
 
 from .base import StixTransform
 from .text import StixTextTransform
@@ -29,24 +32,4 @@ from .csv import StixCsvTransform
 from .brointel import StixBroIntelTransform
 from .snort import StixSnortTransform
 from .misp import StixMispTransform
-
-
-TRANSFORM_CLASS = {
-    'text': StixTextTransform,
-    'stats': StixStatsTransform,
-    'csv': StixCsvTransform,
-    'brointel': StixBroIntelTransform,
-    'snort': StixSnortTransform,
-    'misp': StixMispTransform,
-}
-
-
-def transform_package(package, transform, transform_kwargs):
-    """Loads a STIX package and runs a transform over it."""
-    if transform in TRANSFORM_CLASS:
-        transform_class = TRANSFORM_CLASS[transform]
-        transform = transform_class(package, **transform_kwargs)
-        if isinstance(transform, StixTextTransform):
-            sys.stdout.write(transform.text())
-        elif isinstance(transform, StixMispTransform):
-            transform.publish()
+from .test import StixTestTransform

--- a/certau/transform/test.py
+++ b/certau/transform/test.py
@@ -1,0 +1,58 @@
+from .text import StixTextTransform
+from stix.common import EncodedCDATA
+import glob
+
+class StixTestTransform(StixTextTransform):
+    """Generate text output of test mechanisms contained within a
+    STIX package.
+
+    This class can be used to generate a text dump of the test mechanisms
+    associated with indicators contained in a STIX package.
+
+    Args:
+        package: the STIX package to process
+    """
+
+    def __init__(self, package, default_title=None, default_description=None,
+                 default_tlp='AMBER', separator='|', include_header=False,
+                 header_prefix='#', include_observable_id=True,
+                 include_condition=True):
+        super(StixTextTransform, self).__init__(
+            package, default_title, default_description, default_tlp,
+        )
+        self.include_observable_id = include_observable_id
+        self.include_condition = include_condition
+        self.include_header = include_header
+        self.header_prefix = header_prefix
+
+    def header(self):
+        title = self.package_title()
+        tlp = self.package_tlp()
+
+        if title or tlp:
+            header = self.header_prefix
+            if title:
+                header += ' {}'.format(title)
+            if tlp:
+                header += ' (TLP:{})'.format(tlp)
+            header += '\n'
+        else:
+            header = ''
+        return header
+
+    def text(self):
+        """Returns a string representation of the STIX package."""
+        text = ''
+        for indicator in self.test_mechanisms:
+            if (indicator.test_mechanisms is not None): # should never happen
+                for tm in indicator.test_mechanisms:
+                    if self.include_header:
+                        text += '=' * (len(indicator.id_) + 14) + '\n'
+                        text += self.header()
+                        text += "{:>13} {}".format('Indicator ID:',indicator.id_) + '\n'
+                        text += '=' * (len(indicator.id_) + 14) + '\n'
+
+                    for thing in tm.walk():
+                        if (isinstance(thing, EncodedCDATA)):
+                            text += '{}'.format(thing.value) + '\n'
+        return text

--- a/certau/util/config.py
+++ b/certau/util/config.py
@@ -29,27 +29,19 @@ def get_arg_parser():
         help="configuration file to use",
     )
     global_group.add_argument(
+        "-v", "--verbose",
+        action="store_true",
+        help="verbose output",
+    )
+    global_group.add_argument(
+        "-d", "--debug",
+        action="store_true",
+        help="enable debug output",
+    )
+    global_group.add_argument(
         "-V", "--version",
         action="version",
         version="{} (by CERT Australia)".format(version_string),
-    )
-
-    # Logging options
-    logging_ex_group = global_group.add_mutually_exclusive_group()
-    logging_ex_group.add_argument(
-        "-q", "--quiet",
-        action="store_true",
-        help="suppress warnings and informational logs",
-    )
-    logging_ex_group.add_argument(
-        "-v", "--verbose",
-        action="store_true",
-        help="verbose logging",
-    )
-    logging_ex_group.add_argument(
-        "-d", "--debug",
-        action="store_true",
-        help="most verbose (debug) logging",
     )
 
     # Source options
@@ -82,6 +74,12 @@ def get_arg_parser():
         "-t", "--text",
         action="store_true",
         help="output observables in delimited text",
+    )
+    output_ex_group.add_argument(
+        "-T", "--test_mechanisms",
+        action="store_true",
+        help=("output indicator test mechanisms contained within package" +
+             "(eg Yara / Snort)"),
     )
     output_ex_group.add_argument(
         "-b", "--bro",


### PR DESCRIPTION
…that for a given STIX package will output the test mechanisms associated with any indicators. Typically these will be snort or yara rules.

Test mechanism specifics are detailed at:
http://stixproject.github.io/data-model/1.2/indicator/TestMechanismType/

The new transform is activated with the -T | --test_mechanisms argument. This new option works with the --header option to allow / supress the printing of header fields.