### PR TITLE
Misp info overrides#2

### DIFF
--- a/certau/scripts/stixtransclient.py
+++ b/certau/scripts/stixtransclient.py
@@ -174,10 +174,11 @@ def main():
                 source_item.save(options.xml_output)
             else:
                 # Peel off the filenames as they come in
-                try:
-                    transform_kwargs['file_name'] = source_item.file_name()
-                except:
-                    transform_kwargs['file_name'] = ""
+                if transform == 'misp':
+                    try:
+                        transform_kwargs['file_name'] = source_item.file_name()
+                    except:
+                        transform_kwargs['file_name'] = ""
                 transform_package(package, transform, transform_kwargs)
 
 

--- a/certau/transform/misp.py
+++ b/certau/transform/misp.py
@@ -215,7 +215,10 @@ class StixMispTransform(StixTransform):
                 file_name = self.file_name
             else:
                 file_name = self.file_name[0:wheresmydot]
-
+            # Filename reader can pick up some of the path somehow
+            whyisthereaslash = file_name.rfind('/')
+            if (whyisthereaslash > 0):
+                file_name = file_name[whyisthereaslash+1:]
 
             if self.info_filename_title:
                 if title:

--- a/tests/test_client_script.py
+++ b/tests/test_client_script.py
@@ -24,7 +24,6 @@ def test_text_file_basic_transform(client_wrapper):
         default_title=None,
         default_description=None,
         default_tlp='AMBER',
-        file_name='tests/CA-TEST-STIX.xml',
     )
 
 


### PR DESCRIPTION
After further testing, identified that a file-path sometimes slips into the file_name field.
The filename only matter for MISP, so there is now a check.